### PR TITLE
Open in specific apps

### DIFF
--- a/utils/in-app-escape.ts
+++ b/utils/in-app-escape.ts
@@ -66,29 +66,25 @@ export const inAppEscape = (long_url: string, userAgent: string): string => {
         const url = new URL(long_url);
 
         // Handle to open specific apps directly
-        switch (true) {
-          // YouTube
-          case hostname.includes("youtube"):
-          case hostname.includes("youtu.be"): {
-            const newUrl = url.pathname + url.search + url.hash;
-            return "youtube://" + newUrl.substring(1);
-          }
-          // Spotify
-          case hostname.includes("spotify.com"): {
-            const pathParts = url.pathname.split("/").filter(Boolean); // e.g., ['artist', 'artistId']
-            if (
-              pathParts.length >= 2 &&
-              ["artist", "track", "album"].includes(pathParts[0])
-            ) {
-              const [type, id] = pathParts;
-              return `spotify:${type}:${id}`;
-            }
-            // Fallback for other spotify links
-            return safariHttps + url.toString();
-          }
 
-          default:
-            return safariHttps + url.toString();
+        // YouTube
+        if (hostname.includes("youtube") || hostname.includes("youtu.be")) {
+          const newUrl = url.pathname + url.search + url.hash;
+          return "youtube://" + newUrl.substring(1);
+          // Spotify
+        } else if (hostname.includes("spotify.com")) {
+          const pathParts = url.pathname.split("/").filter(Boolean); // e.g., ['artist', 'artistId']
+          if (
+            pathParts.length >= 2 &&
+            ["artist", "track", "album"].includes(pathParts[0])
+          ) {
+            const [type, id] = pathParts;
+            return `spotify:${type}:${id}`;
+          }
+          // Fallback for other spotify links
+          return safariHttps + url.toString();
+        } else {
+          return safariHttps + url.toString();
         }
       }
       case "android": {


### PR DESCRIPTION
This pull request enhances the `inAppEscape` utility function to better handle escaping in-app browsers on mobile devices, with new support for deep linking to native apps (YouTube and Spotify) on iOS. The documentation is also expanded with clearer explanations and examples.

Improvements to mobile deep linking:

* Added logic to detect YouTube and Spotify URLs on iOS and transform them into their respective deep link URIs (e.g., `youtube://watch?v=...` and `spotify:track:id`), allowing direct opening in the native app instead of Safari.
* For other URLs on iOS, the function continues to prepend `x-safari-` to force opening in Safari.
* Android URLs are now consistently converted to Android Intent format for external browser opening.

Documentation and code clarity:

* Expanded and clarified the function documentation, including detailed remarks and usage examples for iOS, Android, and fallback cases.
* Improved variable naming and added parsing for the hostname to support new deep link logic.