### PR TITLE
feat: add release-please GitHub Actions workflow for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          release-type: node


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate releases using Release Please. The workflow is triggered on pushes to the `main` branch and uses the Release Please GitHub Action to manage release creation for a Node.js project.

Release automation:

* Added a new workflow file `.github/workflows/release-please.yml` that sets up Release Please to run on pushes to `main`, with permissions for contents and pull requests, and uses the `googleapis/release-please-action@v4` for Node.js releases.