### PR TITLE
Ux improvements

### DIFF
--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -253,6 +253,7 @@ export default function Dashboard({
         onSearchChange={setQuery}
         sort={sort}
         onSortChange={setSort}
+        linkCount={links.length}
       />
       <main className="c-root grow flex mb-4 w-full justify-center">
         <section className="flex flex-col w-full">

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -4,6 +4,8 @@ import { redirect, useFetcher } from "react-router";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
 import LinkCard from "@/components/links/link-card";
+import CreateLink from "@/components/links/create-link";
+import { Button } from "@/components/ui/button";
 import { getAuth } from "@clerk/react-router/ssr.server";
 import type { Route } from "./+types/dashboard";
 import type { ActionFunctionArgs } from "react-router";
@@ -14,6 +16,7 @@ import { copyToClipboard } from "@/utils/copy-to-clipboard";
 import type { SortValue, SortKey } from "@/components/links/sort-links";
 
 import { toast } from "sonner";
+import { Plus } from "lucide-react";
 
 // eslint-disable-next-line no-empty-pattern
 export function meta({}: Route.MetaArgs) {
@@ -269,9 +272,28 @@ export default function Dashboard({
             ))}
           </div>
           {visibleLinks.length === 0 && (
-            <p className="text-sm text-muted-foreground mt-4">
-              No results for “{query}”.
-            </p>
+            <div className="flex flex-col items-center justify-center text-center mt-8 gap-4">
+              {query ? (
+                <p className="text-sm text-muted-foreground">
+                  No results for “{query}”.
+                </p>
+              ) : (
+                <>
+                  <h3 className="text-lg font-semibold">
+                    No links created yet
+                  </h3>
+                  <p className="text-sm text-muted-foreground">
+                    Get started by creating your first short link.
+                  </p>
+                  <CreateLink>
+                    <Button variant="outline">
+                      <Plus strokeWidth={2} />
+                      Create your first link
+                    </Button>
+                  </CreateLink>
+                </>
+              )}
+            </div>
           )}
         </section>
       </main>

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -285,7 +285,7 @@ export default function Dashboard({
                   <p className="text-sm text-muted-foreground">
                     Get started by creating your first short link.
                   </p>
-                  <CreateLink>
+                  <CreateLink linkCount={links.length}>
                     <Button variant="outline">
                       <Plus strokeWidth={2} />
                       Create your first link

--- a/app/routes/disclaimer.tsx
+++ b/app/routes/disclaimer.tsx
@@ -21,7 +21,7 @@ export default function Disclaimer() {
 
   return (
     <div className="flex min-h-dvh flex-col items-center justify-between antialiased">
-      <Header />
+      <Header onDocs />
       <main className="c-root grow flex items-start justify-center py-8">
         <section className="max-w-2xl w-full space-y-6">
           <h1 className="text-3xl font-bold">Disclaimer</h1>

--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -13,7 +13,7 @@ export function meta() {
 export default function TermsOfService() {
   return (
     <div className="flex min-h-dvh flex-col items-center justify-between antialiased">
-      <Header />
+      <Header onDocs />
       <main className="c-root grow flex items-start justify-center py-8">
         <section className="max-w-2xl w-full space-y-6">
           <h1 className="text-3xl font-bold">Privacy Policy</h1>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -5,56 +5,39 @@ import { Separator } from "@ui/separator";
 
 export default function Footer() {
   return (
-    <footer className="c-root w-full backdrop-blur-xl backdrop-saturate-150 py-4">
+    <footer className="c-root w-full py-4">
       <div className="text-xs text-muted-foreground flex flex-col-reverse gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex w-full items-center gap-2 sm:justify-start">
-          <p className="whitespace-nowrap w-full">
-            Made by Andres using{" "}
-            <Link
-              to="https://reactrouter.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:underline"
-            >
-              React Router
-              <ExternalLink className="ml-1 inline" size={14} />
-            </Link>
-          </p>
-          <div className="block sm:hidden">
-            <Link
-              to="https://github.com/andesvel/nuto/issues/new?assignees=&labels=bug&template=bug_report.md&title="
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:underline whitespace-nowrap"
-            >
-              Report a bug
-              <span className="sr-only">Report a bug</span>
-              <ExternalLink className="ml-1 inline" size={14} />
-            </Link>
-          </div>
-        </div>
+        <p className="text-center sm:text-left">
+          Made by Andres using{" "}
+          <Link
+            to="https://reactrouter.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            React Router
+            <ExternalLink className="ml-1 inline" size={14} />
+          </Link>
+        </p>
 
-        <div className="h-4 flex w-full items-center gap-2 sm:justify-end">
+        <div className="h-4 flex items-center justify-center gap-2">
           <Link to="/disclaimer" className="hover:underline">
             Disclaimer
           </Link>
-          <Separator orientation="vertical" />
+          <Separator orientation="vertical" className="h-4" />
           <Link to="/privacy" className="hover:underline">
             Privacy policy
           </Link>
-          <Separator orientation="vertical" className="hidden sm:block" />
-          <div className="hidden sm:block">
-            <Link
-              to="https://github.com/andesvel/nuto/issues/new?assignees=&labels=bug&template=bug_report.md&title="
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:underline"
-            >
-              Report a bug
-              <span className="sr-only">Report a bug</span>
-              <ExternalLink className="ml-1 inline" size={14} />
-            </Link>
-          </div>
+          <Separator orientation="vertical" className="h-4" />
+          <Link
+            to="https://github.com/andesvel/nuto/issues/new?assignees=&labels=bug&template=bug_report.md&title="
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            Report a bug
+            <ExternalLink className="ml-1 inline" size={14} />
+          </Link>
         </div>
       </div>
     </footer>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -24,11 +24,11 @@ export default function Footer() {
           <Link to="/disclaimer" className="hover:underline">
             Disclaimer
           </Link>
-          <Separator orientation="vertical" className="h-4" />
+          <Separator orientation="vertical" />
           <Link to="/privacy" className="hover:underline">
             Privacy policy
           </Link>
-          <Separator orientation="vertical" className="h-4" />
+          <Separator orientation="vertical" />
           <Link
             to="https://github.com/andesvel/nuto/issues/new?assignees=&labels=bug&template=bug_report.md&title="
             target="_blank"

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -43,7 +43,7 @@ export default function Header({
       <header className="mb-4 sticky top-0 z-50 w-full backdrop-blur-sm backdrop-saturate-150 supports-[backdrop-filter]:bg-card/30 standalone:pt-12 standalone:fixed">
         <div className="c-root flex flex-col">
           <div className="flex h-16 items-center justify-between">
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center gap-2">
               <NutoLogo withText />
               {onDocs && (
                 <SignedIn>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -21,6 +21,7 @@ export default function Header({
   onDashboard,
   onDocs,
   hideSession,
+  linkCount,
   searchQuery,
   onSearchChange,
   sort,
@@ -29,6 +30,7 @@ export default function Header({
   onDashboard?: boolean;
   onDocs?: boolean;
   hideSession?: boolean;
+  linkCount?: number;
   searchQuery?: string;
   onSearchChange?: (q: string) => void;
   sort?: SortValue;
@@ -131,6 +133,16 @@ export default function Header({
                 />
               </div>
               <div className="flex items-center gap-2">
+                {linkCount !== undefined && (
+                  <div className="h-9 flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm backdrop-blur-xl backdrop-saturate-150 bg-background/30 shadow-xs">
+                    <span className="font-medium text-foreground">
+                      {linkCount}
+                    </span>
+                    <span className="text-muted-foreground">
+                      / 50 <span className="hidden sm:inline">links</span>
+                    </span>
+                  </div>
+                )}
                 {sort && onSortChange && (
                   <SortLinks value={sort} onChange={onSortChange}>
                     <Button variant="outline">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link } from "react-router";
+import { Link, useNavigation } from "react-router";
 import { ThemeSwitcher } from "@/components/theme-switcher";
 import {
   SignedIn,
@@ -11,7 +11,7 @@ import { LogIn } from "lucide-react";
 import { SiGithub } from "@icons-pack/react-simple-icons";
 import { Button } from "./ui/button";
 import { Input } from "@ui/input";
-import { Search, ArrowUpDown } from "lucide-react";
+import { Search, ArrowUpDown, Loader, ArrowRight } from "lucide-react";
 import { NutoLogo } from "@components/icons/logo";
 
 import CreateLink from "@components/links/create-link";
@@ -19,6 +19,7 @@ import SortLinks, { type SortValue } from "@/components/links/sort-links";
 
 export default function Header({
   onDashboard,
+  onDocs,
   hideSession,
   searchQuery,
   onSearchChange,
@@ -26,18 +27,57 @@ export default function Header({
   onSortChange,
 }: {
   onDashboard?: boolean;
+  onDocs?: boolean;
   hideSession?: boolean;
   searchQuery?: string;
   onSearchChange?: (q: string) => void;
   sort?: SortValue;
   onSortChange?: (v: SortValue) => void;
 }) {
+  const navigation = useNavigation();
+  const isNavigatingToDashboard =
+    navigation.state === "loading" &&
+    navigation.location.pathname === "/dashboard";
   return (
     <>
       <header className="mb-4 sticky top-0 z-50 w-full backdrop-blur-sm backdrop-saturate-150 supports-[backdrop-filter]:bg-card/30 standalone:pt-12 standalone:fixed">
         <div className="c-root flex flex-col">
           <div className="flex h-16 items-center justify-between">
-            <NutoLogo withText />
+            <div className="flex items-center space-x-2">
+              <NutoLogo withText />
+              {onDocs && (
+                <SignedIn>
+                  <Link to="/dashboard">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="group"
+                      disabled={isNavigatingToDashboard}
+                    >
+                      {isNavigatingToDashboard ? (
+                        <>
+                          <Loader
+                            size={24}
+                            strokeWidth={2}
+                            className="mr-2 animate-spin"
+                          />
+                          Loading
+                        </>
+                      ) : (
+                        <>
+                          Go to dashboard
+                          <ArrowRight
+                            size={24}
+                            strokeWidth={2}
+                            className="duration-300 group-hover:translate-x-0.5"
+                          />
+                        </>
+                      )}
+                    </Button>
+                  </Link>
+                </SignedIn>
+              )}
+            </div>
             <div className="flex items-center gap-4">
               <ThemeSwitcher />
               <div className="flex items-center">

--- a/components/links/create-link.tsx
+++ b/components/links/create-link.tsx
@@ -25,7 +25,11 @@ import { toast } from "sonner";
 
 import { Plus, Shuffle, Eye, EyeOff, Eraser, Loader } from "lucide-react";
 
-export default function CreateLink() {
+export default function CreateLink({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
   const fetcher = useFetcher();
   const busy = fetcher.state !== "idle";
   const [open, setOpen] = useState(false);
@@ -115,10 +119,14 @@ export default function CreateLink() {
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogTrigger asChild>
-        <Button>
-          <Plus strokeWidth={2} />
-          <span className="hidden md:inline-block">New Link</span>
-        </Button>
+        {children ? (
+          children
+        ) : (
+          <Button>
+            <Plus strokeWidth={2} />
+            <span className="hidden md:inline-block">New Link</span>
+          </Button>
+        )}
       </DialogTrigger>
       <DialogContent className="sm:max-w-[425px] md:max-w-[512px]">
         <DialogHeader>

--- a/components/links/create-link.tsx
+++ b/components/links/create-link.tsx
@@ -27,8 +27,10 @@ import { Plus, Shuffle, Eye, EyeOff, Eraser, Loader } from "lucide-react";
 
 export default function CreateLink({
   children,
+  linkCount,
 }: {
   children?: React.ReactNode;
+  linkCount?: number;
 }) {
   const fetcher = useFetcher();
   const busy = fetcher.state !== "idle";
@@ -122,7 +124,7 @@ export default function CreateLink({
         {children ? (
           children
         ) : (
-          <Button>
+          <Button disabled={linkCount !== undefined && linkCount >= 50}>
             <Plus strokeWidth={2} />
             <span className="hidden md:inline-block">New Link</span>
           </Button>

--- a/components/links/edit-link.tsx
+++ b/components/links/edit-link.tsx
@@ -14,6 +14,11 @@ import {
   DialogFooter,
   DialogClose,
 } from "@/components/ui/dialog";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -23,7 +28,17 @@ import { toast } from "sonner";
 import { ExpirationPicker } from "@/components/links/expiration-picker";
 import { generateShortCode } from "@utils/generate-short-code";
 
-import { Plus, Shuffle, Eye, EyeOff, Eraser, Edit, Loader } from "lucide-react";
+import {
+  Plus,
+  Shuffle,
+  Eye,
+  EyeOff,
+  Eraser,
+  Edit,
+  Loader,
+  Lock,
+  Unlock,
+} from "lucide-react";
 
 export default function EditLink({
   children,
@@ -47,6 +62,7 @@ export default function EditLink({
   const { isValid, isReserved, hasValidChars } = shortCodeValidation;
   const shortCodeHasValue = (formData.shortCode ?? "").trim().length > 0;
   const showShortCodeError = shortCodeHasValue && !isValid;
+  const [isShortCodeLocked, setIsShortCodeLocked] = useState(true);
 
   useEffect(() => {
     if (fetcher.data && fetcher.state === "idle") {
@@ -127,6 +143,7 @@ export default function EditLink({
       setExpires(link.expiresAt !== null);
       setHasPassword(link.password !== null);
       setViewPassword(false);
+      setIsShortCodeLocked(true);
       setSelectedDate(link.expiresAt ? new Date(link.expiresAt) : undefined);
       setFormData(link);
     }, 200);
@@ -212,6 +229,7 @@ export default function EditLink({
                   spellCheck={false}
                   inputMode="text"
                   pattern="[0-9A-Za-z]+"
+                  disabled={isShortCodeLocked}
                   value={formData.shortCode}
                   onChange={handleInputChange}
                   aria-invalid={showShortCodeError || undefined}
@@ -219,15 +237,50 @@ export default function EditLink({
                     showShortCodeError ? "shortCode-error" : undefined
                   }
                 />
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="rounded-l-none"
-                  onClick={handleRandomize}
-                >
-                  <Shuffle strokeWidth={2} />
-                  Randomize
-                </Button>
+                {isShortCodeLocked ? (
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="rounded-l-none"
+                      >
+                        <Lock strokeWidth={2} />
+                        Unlock
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-80">
+                      <div className="grid gap-4">
+                        <div className="space-y-2">
+                          <h4 className="font-medium leading-none">
+                            Change Short Code
+                          </h4>
+                          <p className="text-sm text-muted-foreground">
+                            Changing the short code will break existing links.
+                            Share the new link to grant access.
+                          </p>
+                        </div>
+                        <Button
+                          variant="destructive"
+                          onClick={() => setIsShortCodeLocked(false)}
+                        >
+                          <Unlock className="mr-2 h-4 w-4" /> I understand,
+                          unlock
+                        </Button>
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="rounded-l-none"
+                    onClick={handleRandomize}
+                  >
+                    <Shuffle strokeWidth={2} />
+                    Randomize
+                  </Button>
+                )}
               </div>
               {formData.shortCode && hasValidChars === false && (
                 <p


### PR DESCRIPTION
This pull request introduces several UX and UI improvements across the dashboard, header, footer, and link management components. The most notable changes include enhancements to the empty state experience on the dashboard, improved navigation between documentation and dashboard, a new short code locking mechanism in link editing, and visual updates to the header and footer. These changes collectively make the app more intuitive and user-friendly.

**Dashboard and Empty State Enhancements**
* Added a more informative empty state to the dashboard when no links exist, including a call-to-action button to create a new link using the `CreateLink` component. The button is disabled when the user has reached the link limit. [[1]](diffhunk://#diff-746541825ad0b8e1100310b9f34de78d8879d6be6786c9407f19444fce22f591L271-R296) [[2]](diffhunk://#diff-35e827fd9f998bcce406d4ea37fa5ac753fe37a5a0dc8355c6ae512b1792359aL118-R131)
* Passed `linkCount` to both the header and create link components to display the current number of links and enforce the maximum limit. [[1]](diffhunk://#diff-746541825ad0b8e1100310b9f34de78d8879d6be6786c9407f19444fce22f591R259) [[2]](diffhunk://#diff-cf7e29e4902dea0aa000da86f34225ba6d7a6d13c982343f255b15f827269199R136-R145) [[3]](diffhunk://#diff-35e827fd9f998bcce406d4ea37fa5ac753fe37a5a0dc8355c6ae512b1792359aL28-R34)

**Header and Navigation Improvements**
* Updated the `Header` component to support an `onDocs` prop, showing a "Go to dashboard" button (with loading state) when viewing documentation pages. This improves navigation between docs and dashboard for signed-in users. [[1]](diffhunk://#diff-cf7e29e4902dea0aa000da86f34225ba6d7a6d13c982343f255b15f827269199L2-R2) [[2]](diffhunk://#diff-cf7e29e4902dea0aa000da86f34225ba6d7a6d13c982343f255b15f827269199L14-R82)
* Added a visual indicator of the user's link usage in the header, showing the current count out of the maximum allowed links.

**Footer Redesign**
* Simplified the footer layout for better responsiveness and clarity, moving the "Report a bug" link to always be visible and improving the arrangement of legal links. [[1]](diffhunk://#diff-bd3f659ee78d8c923c9975bdb8842b2a346ff04023e42fe215c0d080ef5cf115L8-R10) [[2]](diffhunk://#diff-bd3f659ee78d8c923c9975bdb8842b2a346ff04023e42fe215c0d080ef5cf115L23-L59)

**Link Editing UX**
* Introduced a locking mechanism for short codes in the `EditLink` dialog. Users must explicitly unlock the short code (with a warning about breaking existing links) before they can edit it, reducing accidental changes. [[1]](diffhunk://#diff-c2b29b3684d594f8c35a0fa6385bcc49da747b0861df0502a5ef0e31461f5b84R65) [[2]](diffhunk://#diff-c2b29b3684d594f8c35a0fa6385bcc49da747b0861df0502a5ef0e31461f5b84R146) [[3]](diffhunk://#diff-c2b29b3684d594f8c35a0fa6385bcc49da747b0861df0502a5ef0e31461f5b84R232-R273) [[4]](diffhunk://#diff-c2b29b3684d594f8c35a0fa6385bcc49da747b0861df0502a5ef0e31461f5b84R283)
* Added supporting UI components (`Popover`, `Lock`, `Unlock`) to facilitate the short code lock/unlock flow. [[1]](diffhunk://#diff-c2b29b3684d594f8c35a0fa6385bcc49da747b0861df0502a5ef0e31461f5b84R17-R21) [[2]](diffhunk://#diff-c2b29b3684d594f8c35a0fa6385bcc49da747b0861df0502a5ef0e31461f5b84L26-R41)

**Documentation Page Consistency**
* Updated disclaimer and privacy policy pages to use the new header variant with the docs navigation improvements. [[1]](diffhunk://#diff-fe17768869a0a676b3461722c303a6f95ad5d3868676229ebc2617d2e865d9b3L24-R24) [[2]](diffhunk://#diff-a5655e4db321f7aa688aeaaec55666276805198774095091d79d6fcc467f0f3eL16-R16)