### PR TITLE
Fix: couldn't save edition in link when input is disabled

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -157,7 +157,7 @@ export default function Header({
           )}
         </div>
       </header>
-      <div className="h-0 standalone:h-8"></div>
+      {/* <div className="h-0 standalone:h-8"></div> */}
     </>
   );
 }

--- a/components/links/edit-link.tsx
+++ b/components/links/edit-link.tsx
@@ -237,6 +237,13 @@ export default function EditLink({
                     showShortCodeError ? "shortCode-error" : undefined
                   }
                 />
+                {isShortCodeLocked && (
+                  <input
+                    type="hidden"
+                    name="shortCode"
+                    value={formData.shortCode}
+                  />
+                )}
                 {isShortCodeLocked ? (
                   <Popover>
                     <PopoverTrigger asChild>


### PR DESCRIPTION
This pull request introduces a minor UI update and a form handling improvement. The most notable change is the addition of a hidden input field to ensure that locked short codes are submitted with the form, which helps preserve data integrity when editing links.

Form handling improvement:

* Added a hidden `shortCode` input field to the `EditLink` form when the short code is locked, ensuring its value is submitted with the form.

UI update:

* Commented out a spacer `div` in the `Header` component, possibly to adjust layout or for future reference.