### PR TITLE
add CTA to landing page

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -4,8 +4,9 @@ import Header from "@components/header";
 import Hero from "@components/hero";
 import Footer from "@/components/footer";
 import { Features } from "@/components/features";
-import { Separator } from "@/components/ui/separator";
+// import { Separator } from "@/components/ui/separator";
 import { NameOrigin } from "@/components/name-origin";
+import { CtaSection } from "@/components/cta-section";
 
 // eslint-disable-next-line no-empty-pattern
 export function meta({}: Route.MetaArgs) {
@@ -33,9 +34,10 @@ export default function Home() {
       <main className="c-root grow flex flex-col items-center justify-start">
         <Hero />
         <Features />
-        <Separator className="my-2 sm:hidden" decorative />
+        {/* <Separator className="my-2 sm:hidden" decorative /> */}
         <NameOrigin />
-        <Separator className="my-2 sm:hidden" decorative />
+        {/* <Separator className="my-2 sm:hidden" decorative /> */}
+        <CtaSection />
       </main>
       <Footer />
       <div className="absolute inset-0 -z-10 bg-[linear-gradient(to_right,rgba(from_var(--muted-foreground)_r_g_b_/_0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(from_var(--muted-foreground)_r_g_b_/_0.05)_1px,transparent_1px)] bg-[size:1lh_1lh]"></div>

--- a/components/cta-section.tsx
+++ b/components/cta-section.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Link, useNavigation } from "react-router";
+import { Button } from "./ui/button";
+import { SignedIn, SignedOut, SignInButton } from "@clerk/react-router";
+import { ArrowRight, Loader } from "lucide-react";
+
+export function CtaSection() {
+  const navigation = useNavigation();
+  const isNavigatingToDashboard =
+    navigation.state === "loading" &&
+    navigation.location.pathname === "/dashboard";
+
+  return (
+    <section id="cta" className="w-full py-16">
+      <div className="mx-auto max-w-3xl text-center">
+        <h2 className="text-2xl sm:text-3xl font-bold">Ready to begin?</h2>
+        <p className="mt-3 mb-8 text-muted-foreground">
+          Create a free account and start shortening links that open in the
+          right place.
+        </p>
+        <div className="flex justify-center gap-4">
+          <SignedIn>
+            <Link to="/dashboard">
+              <Button
+                className="group"
+                size="lg"
+                disabled={isNavigatingToDashboard}
+              >
+                {isNavigatingToDashboard ? (
+                  <>
+                    <Loader
+                      size={24}
+                      strokeWidth={2}
+                      className="mr-2 animate-spin"
+                    />
+                    Loading
+                  </>
+                ) : (
+                  <>
+                    Go to dashboard
+                    <ArrowRight
+                      size={24}
+                      strokeWidth={2}
+                      className="duration-300 group-hover:translate-x-0.5"
+                    />
+                  </>
+                )}
+              </Button>
+            </Link>
+          </SignedIn>
+          <SignedOut>
+            <SignInButton mode="modal">
+              <Button className="group" size="lg">
+                Get started
+                <ArrowRight
+                  size={24}
+                  strokeWidth={2}
+                  className="duration-300 group-hover:translate-x-0.5"
+                />
+              </Button>
+            </SignInButton>
+          </SignedOut>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/name-origin.tsx
+++ b/components/name-origin.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 export function NameOrigin() {
   return (
-    <section id="name" className="w-full  min-h-[40dvh] flex items-center">
-      <div className="sm:-mt-20 mx-auto max-w-3xl text-center">
+    <section id="name" className="w-full  min-h-[30dvh] flex items-center">
+      <div className="mx-auto max-w-3xl text-center">
         <h2 className="text-2xl sm:text-3xl font-bold">
           What does &quot;Nuto&quot; mean?
         </h2>


### PR DESCRIPTION
This pull request adds a new call-to-action section to the home page and makes minor adjustments to layout and spacing. The most significant change is the introduction of the `CtaSection` component, which provides users with a clear prompt to get started or access their dashboard, depending on their authentication status. Additionally, some separators were commented out to streamline the page's appearance, and the minimum height of the name origin section was reduced for better visual balance.

**New feature:**
* Added the new `CtaSection` component to the home page, providing a clear call-to-action for both signed-in and signed-out users, including navigation logic and loading feedback. (`components/cta-section.tsx`)
* Integrated the `CtaSection` component into the home page layout, ensuring it appears after the name origin section. (`app/routes/home.tsx`) [[1]](diffhunk://#diff-d4d02e1e213a6e908bde87dfb239e6d84dfbaeed2616b5695726416fbb2b2acbL7-R9) [[2]](diffhunk://#diff-d4d02e1e213a6e908bde87dfb239e6d84dfbaeed2616b5695726416fbb2b2acbL36-R40)

**Layout and spacing adjustments:**
* Commented out the `Separator` components between sections on the home page to create a cleaner look. (`app/routes/home.tsx`) [[1]](diffhunk://#diff-d4d02e1e213a6e908bde87dfb239e6d84dfbaeed2616b5695726416fbb2b2acbL7-R9) [[2]](diffhunk://#diff-d4d02e1e213a6e908bde87dfb239e6d84dfbaeed2616b5695726416fbb2b2acbL36-R40)
* Reduced the minimum height of the `NameOrigin` section from `40dvh` to `30dvh` and removed an unnecessary margin class for improved layout. (`components/name-origin.tsx`)