### PR TITLE
Update webhook test: use proxy environment with dummy secret for Clerk webhook

### DIFF
--- a/app/routes/__tests__/webhooks.clerk.test.ts
+++ b/app/routes/__tests__/webhooks.clerk.test.ts
@@ -41,8 +41,9 @@ describe("Clerk Webhooks", () => {
       body: JSON.stringify({ data: { id: "user_wh_1" } }),
     });
 
+    const proxyEnv = { ...env, CLERK_WEBHOOK_SECRET: "whsec_dummy123" };
     const mockContext = {
-      cloudflare: { env, ctx },
+      cloudflare: { env: proxyEnv, ctx },
     } as unknown as AppLoadContext;
 
     const response = (await action({


### PR DESCRIPTION
This pull request makes a small change to the Clerk webhook test setup to ensure the correct webhook secret is used during testing. The environment variable for the webhook secret is now explicitly set in the test context. 

* The `CLERK_WEBHOOK_SECRET` environment variable is set to a dummy value (`whsec_dummy123`) in the test context to ensure consistent and isolated testing of webhook handling.