### PR TITLE
Improve ux writting & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,27 +71,15 @@ The name "Nuto" comes from the Spanish word "diminuto" (tiny), reflecting its pu
 
 ### Prerequisites
 
-- [Node.js v22.14](https://nodejs.org/) or newer
-- [pnpm v10.14](https://pnpm.io) or newer
-- [A Clerk account](https://clerk.com)
-- [A Cloudflare account](https://dash.cloudflare.com/sign-up)
+You will need the following to run Nuto locally:
+
+- [Node.js v22.14+](https://nodejs.org/)
+- [pnpm v10.14+](https://pnpm.io)
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
-- [Visual Studio Code](https://code.visualstudio.com/)
+- A [Clerk account](https://clerk.com) for authentication. *Note: You must configure a Clerk Webhook with user management events for proper ID synchronization. See [Clerk Webhooks docs](https://clerk.com/docs/webhooks/sync-data/).*
+- A [Cloudflare account](https://dash.cloudflare.com/sign-up) for D1 and KV.
 
-
-ℹ️ Nuto uses Clerk Webhooks to manage user IDs, you must create one in your Clerk App with all user management (created, updated, deleted) events in order to work correctly.
-
-Clerk Webhooks docs: <https://clerk.com/docs/webhooks/sync-data/>
-
-Check Clerk quickstart guide: <https://clerk.com/docs/quickstarts/react-router/>
-
-### 1. Fork the Repository
-
-First, fork the repository by clicking on the 'Fork' button on the top right of this page. This will create a copy of the repository in your GitHub account.
-
-### 2. Installation
-
-Clone your forked repository and install the dependencies. Replace `YOUR_USERNAME` with your GitHub username.
+### 1. Installation
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/nuto.git
@@ -99,112 +87,83 @@ cd nuto
 pnpm install
 ```
 
-### 3. Environment Setup
+### 2. Environment Setup
 
-Public env (used by the client, Vite-style):
+Create the required environment files.
 
-```bash
-# .env.local
-# see https://clerk.com/docs/quickstarts/react-router#set-your-clerk-api-keys
+`.env.local` (Client-side variables):
+```env
 VITE_CLERK_PUBLISHABLE_KEY=pk_...
 ```
 
-Worker secrets (used by Wrangler/Workers):
-
-```bash
-# .dev.vars (for `wrangler dev`)
+`.dev.vars` (Worker/Server-side secrets):
+```env
 CLERK_SECRET_KEY="sk_..."
 PASSCODE_ENC_KEY="..."
-
-# optionally, if you use webhooks:
 CLERK_WEBHOOK_SECRET="whsec_..."
 ```
 
-### 4. Development
+### 3. Development Server
 
-Start the development server with HMR:
+Start the Vite development server with HMR:
 
 ```bash
 pnpm dev
 ```
+Your application will be available at http://localhost:5173.
 
-Your application will be available at <http://localhost:5173>.
+---
 
-## 📦 Building for Production
+## ☁️ Deployment
 
-To create a production-ready build, run:
+Cloudflare Workers handles both the SSR routing (via React Router) and the API.
+
+### 1. Build
 
 ```bash
 pnpm build
 ```
 
-This command builds the React application and the Cloudflare Worker.
+### 2. Provision Cloudflare Resources (First time only)
 
-## ☁️ Deploying with Wrangler
-
-1) Login to Cloudflare:
-
+Login to Cloudflare:
 ```bash
 wrangler login
 ```
 
-2) Create resources (only once per account):
-
-- D1 database:
-
+Create the D1 database:
 ```bash
 wrangler d1 create nuto-db
 ```
+*(Update `wrangler.jsonc` with the new `database_id`)*
 
-Copy the created database_id into wrangler.jsonc if it differs.
-
-- KV namespace (production and preview):
-
+Create the KV namespace (for production and preview):
 ```bash
 wrangler kv namespace create URL_STORE
 wrangler kv namespace create URL_STORE --preview
 ```
+*(Update `wrangler.jsonc` with the corresponding `id` and `preview_id`)*
 
-Copy the ids into wrangler.jsonc (id and preview_id).
-
-3) Configure secrets:
+### 3. Configure Secrets
 
 ```bash
 wrangler secret put CLERK_SECRET_KEY
 wrangler secret put PASSCODE_ENC_KEY
-# optional
 wrangler secret put CLERK_WEBHOOK_SECRET
 ```
 
-4) Initialize the database schema:
+### 4. Initialize Database
 
+Execute the schema against your D1 instance:
 ```bash
 wrangler d1 execute nuto-db --file=./schema.sql
 ```
 
-Use the provided schema at [schema.sql](schema.sql). Re-run this command if you update the schema.
-
-5) Deploy:
+### 5. Deploy
 
 ```bash
 pnpm deploy
-# or
-wrangler deploy
 ```
-
-6) Tail logs (useful for debugging):
-
-```bash
-wrangler tail
-```
-
-Helpful Cloudflare docs:
-
-- Workers: <https://developers.cloudflare.com/workers/>
-- Wrangler configuration: <https://developers.cloudflare.com/workers/wrangler/configuration/>
-- KV: <https://developers.cloudflare.com/kv/>
-- D1: <https://developers.cloudflare.com/d1/>
-- Secrets: <https://developers.cloudflare.com/workers/configuration/secrets/>
 
 ## 🗺️ Roadmap
 

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -11,17 +11,20 @@ import { CtaSection } from "@/components/cta-section";
 // eslint-disable-next-line no-empty-pattern
 export function meta({}: Route.MetaArgs) {
   return [
-    { title: "Nuto · Open links where they belong" },
+    { title: "Nuto · A smoother journey for your links" },
     {
       name: "description",
       content:
-        "Short links that escape in-app browsers and open in the native browser. Deep-link to YouTube, Spotify and Apple Music.",
+        "Give your audience the seamless experience they deserve. Nuto's smart links bypass frustrating in-app browsers and open directly in native apps like YouTube and Spotify.",
     },
-    { property: "og:title", content: "Nuto · Open links where they belong" },
+    {
+      property: "og:title",
+      content: "Nuto · A smoother journey for your links",
+    },
     {
       property: "og:description",
       content:
-        "Escape in-app browsers and open links in the right place: native browser or native apps like YouTube, Spotify and Apple Music.",
+        "We fix the broken mobile link experience. Nuto seamlessly routes your visitors to their favorite native apps instead of trapping them in an in-app browser.",
     },
     { name: "twitter:card", content: "summary" },
   ];

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -13,46 +13,49 @@ export function Features() {
       <div className="mx-auto max-w-4xl text-center mb-10">
         <h2 className="text-2xl sm:text-3xl font-bold">Why Nuto</h2>
         <p className="mt-3 text-muted-foreground">
-          Built to route users out of in-app browsers and into the right place:
-          the native browser or the right native app.
+          Stop trapping your audience in broken mobile web views. Nuto gets them
+          where they actually want to go.
         </p>
       </div>
 
       <div className="grid gap-6 sm:grid-cols-2">
         <div className="rounded-lg border p-5">
           <div className="flex items-center gap-2 font-semibold">
-            <CircleArrowOutUpLeft className="h-5 w-5" /> Escape in-app browsers
+            <CircleArrowOutUpLeft className="h-5 w-5" /> Bypass in-app browsers
           </div>
           <p className="mt-2 text-sm text-muted-foreground">
-            Nuto detects in-app contexts and rewrites the destination to open in
-            the native browser, powered by smart user-agent handling.
+            Automatically detect and break free from frustrating app environments
+            like Instagram or TikTok, launching the user&apos;s real browser.
           </p>
         </div>
 
         <div className="rounded-lg border p-5">
           <div className="flex items-center gap-2 font-semibold">
-            <ExternalLink className="h-5 w-5" /> Open in native apps
+            <ExternalLink className="h-5 w-5" /> Launch native apps
           </div>
           <p className="mt-2 text-sm text-muted-foreground">
-            Deep-links into apps like YouTube, Spotify and Apple Music.
+            Seamlessly deep-link your visitors straight into the apps they already
+            have installed, like YouTube, Spotify, or Apple Music.
           </p>
         </div>
 
         <div className="rounded-lg border p-5">
           <div className="flex items-center gap-2 font-semibold">
-            <Shield className="h-5 w-5" /> Password-protected links
+            <Shield className="h-5 w-5" /> Secure your links
           </div>
           <p className="mt-2 text-sm text-muted-foreground">
-            Gate sensitive links with a password before redirecting.
+            Add an extra layer of privacy by gating your sensitive content behind
+            a custom password.
           </p>
         </div>
 
         <div className="rounded-lg border p-5">
           <div className="flex items-center gap-2 font-semibold">
-            <Timer className="h-5 w-5" /> Expiration & click insights
+            <Timer className="h-5 w-5" /> Auto-expiring links
           </div>
           <p className="mt-2 text-sm text-muted-foreground">
-            Set expiry for temporary shares and track basic click metrics.
+            Create temporary links that self-destruct after a set time, and seamlessly track
+            how many clicks you&apos;re getting.
           </p>
         </div>
       </div>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -13,14 +13,15 @@ export default function Hero() {
     <section className="w-full grow min-h-[90dvh] flex flex-col items-center justify-center text-center p-2 px-4 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-3xl text-center content-center mt-auto">
         <div className="backdrop-blur-sm backdrop-saturate-150 inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium text-muted-foreground mb-4">
-          Escapes in-app browsers
+          Give your users a better experience
         </div>
         <h1 className="mb-4 text-5xl font-extrabold tracking-tight sm:text-5xl md:text-6xl">
-          Open links where they belong
+          Stop losing visitors to clunky in-app browsers
         </h1>
         <p className="mb-10 text-muted-foreground md:text-md">
-          Short links that escape in-app browsers and open in the native
-          browser. Nuto can deep-link to YouTube, Spotify and Apple Music.
+          Create smart short links that route your audience straight to the apps
+          they love like YouTube, Spotify, or Apple Music, skipping the in-app
+          browser entirely.
         </p>
       </div>
       <div className="flex justify-center gap-4 mb-auto">

--- a/components/name-origin.tsx
+++ b/components/name-origin.tsx
@@ -8,11 +8,10 @@ export function NameOrigin() {
           What does &quot;Nuto&quot; mean?
         </h2>
         <p className="mt-3 text-muted-foreground">
-          &quot;Nuto&quot; comes from the Spanish word &quot;diminuto&quot;
-          (tiny). Because it&apos;s a URL shortener, your long link becomes{" "}
-          <span className="font-semibold">dimi-nuto</span>, the short part is{" "}
-          <span className="font-semibold">nuto</span>. A nod to making links
-          tiny and opening them in the right place.
+          It&apos;s short for &quot;diminuto&quot;, the Spanish word for tiny.
+          We take your messy URLs and make them{" "}
+          <span className="font-semibold">dimi-nuto</span>, so they&apos;re easy
+          to share and never break in mobile apps.
         </p>
       </div>
     </section>


### PR DESCRIPTION
This pull request focuses on improving the clarity and appeal of Nuto's documentation and marketing copy. The changes update the README and main site content to better communicate Nuto's value proposition, simplify onboarding, and use more user-centric language throughout.

**Documentation & Onboarding Improvements:**
- Rewrote and reorganized the `README.md` to clarify prerequisites, streamline setup steps, and provide concise instructions for local development, Cloudflare resource provisioning, and deployment. Added direct links to relevant documentation and emphasized the importance of Clerk Webhook setup.

**Marketing & Messaging Updates:**
- Updated the home page meta tags and descriptions in `app/routes/home.tsx` to use friendlier, benefit-focused language, highlighting seamless user experiences and Nuto's unique value.
- Revised the hero section in `components/hero.tsx` to emphasize solving the problem of in-app browsers and guiding users to their preferred apps, using more engaging and less technical copy.
- Refreshed the features list in `components/features.tsx` with clearer, action-oriented language, making the benefits and use cases more relatable (e.g., "Bypass in-app browsers", "Launch native apps", "Secure your links", "Auto-expiring links").
- Simplified the explanation of the product name in `components/name-origin.tsx` for better readability and connection with the audience.